### PR TITLE
Install requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fabric
 python-novaclient
-mock
 pyyaml
+python-glanceclient

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,17 @@ try:
 except:
     from distutils.core import setup
 
+import os
+
+
+def parse_requirements(requirements_filename='requirements.txt'):
+    requirements = []
+    if os.path.exists(requirements_filename):
+        with open(requirements_filename) as requirements_file:
+            for requirement in requirements_file:
+                requirements.append(requirement)
+    return requirements
+
 config = dict(
     name='cloudenvy',
     version='0.1.0',
@@ -10,8 +21,7 @@ config = dict(
     description='Fast provisioning on openstack clouds.',
     author='Brian Waldon',
     author_email='bcwaldon@gmail.com',
-    install_requires=['fabric', 'python-novaclient', 'pyyaml',
-                      'python-glanceclient'],
+    install_requires=parse_requirements(),
     packages=['cloudenvy'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This eliminates the redundant requirements listings, which had already
drifted apart.
