### PR TITLE
Adding `envy run` command to run arbitrary shell commands from the comfort of your own $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ NOTE: It is highly recommended that you enable SSH Agent Forwarding. The fastest
     ssh-add
 
 
+### Run a command on your ENVy
+
+    envy run "ls ~/foo"
+
 ### Destroy your ENVy
 
 Destroy your instance

--- a/cloudenvy/commands/envy_run.py
+++ b/cloudenvy/commands/envy_run.py
@@ -1,0 +1,33 @@
+import logging
+
+import fabric.api
+import fabric.operations
+
+from cloudenvy.envy import Envy
+
+
+class EnvyRun(object):
+    """Run commands on your ENVy"""
+
+    def __init__(self, argparser):
+        self._build_subparser(argparser)
+
+    def _build_subparser(self, subparsers):
+        subparser = subparsers.add_parser('run', help='run help')
+        subparser.set_defaults(func=self.run)
+
+        subparser.add_argument('command')
+        subparser.add_argument('-n', '--name', action='store', default='',
+                               help='specify custom name for an ENVy')
+        return subparser
+
+    def run(self, config, args):
+        envy = Envy(config)
+
+        if envy.ip():
+            host_string = '%s@%s' % (envy.remote_user, envy.ip())
+            with fabric.api.settings(host_string=host_string):
+                fabric.operations.run(args.command)
+        else:
+            logging.error('Unable to run command on ENVy, perhaps its not '
+                          'booted yet?.')

--- a/cloudenvy/main.py
+++ b/cloudenvy/main.py
@@ -14,6 +14,7 @@ from cloudenvy.commands.envy_scp import EnvySCP
 from cloudenvy.commands.envy_dotfiles import EnvyDotfiles
 from cloudenvy.commands.envy_ssh import EnvySSH
 from cloudenvy.commands.envy_destroy import EnvyDestroy
+from cloudenvy.commands.envy_run import EnvyRun
 
 
 def _build_parser():
@@ -35,6 +36,7 @@ def _build_parser():
     EnvyDotfiles(subparsers)
     EnvySSH(subparsers)
     EnvyDestroy(subparsers)
+    EnvyRun(subparsers)
 
     return parser
 


### PR DESCRIPTION
This fixes https://github.com/cloudenvy/cloudenvy/issues/43

For example if you run `envy run "mkdir -p ~/zomg/wtf/bbq"` from your home dir, you should be able to ssh in and see that you have created 3 dirs.
