### PR TITLE
OS_NO_CACHE setting not having any effect.

### DIFF
--- a/cloudenvy/cloud.py
+++ b/cloudenvy/cloud.py
@@ -39,7 +39,8 @@ class CloudAPI(object):
                 self.user,
                 self.password,
                 self.tenant_name,
-                self.auth_url)
+                self.auth_url,
+                no_cache=True)
         return self._client
 
     def list_servers(self):


### PR DESCRIPTION
I'm trying to disable keyring prompts.  To that effect i exported OS_NO_CACHE=1 to my environment.  However, I continue to get prompted for keyring passwords when I issue envy commands.

(Per chat):
[bcwaldon]
I bet i know what it is
I bet we instantiate our novaclient.v1_1.client.Client directly
and the OS_NO_CACHE is a python-novaclient shell layer thing
so we need to manually set os_no_cache in our cloudenvy config
then pass it in to the Client() call
