### PR TITLE
No hosts found. Please specify (single) host string for connection

### DIFF
--- a/cloudenvy/commands/envy_provision.py
+++ b/cloudenvy/commands/envy_provision.py
@@ -30,43 +30,45 @@ class EnvyProvision(object):
 
         logging.info('Running provision scripts for the `%s` ENVy...' %
                      envy.project_config['name'])
+        if envy.ip():
+            with fabric.api.settings(host_string=envy.ip(), user=envy.remote_user,
+                                     forward_agent=True, disable_known_hosts=True):
 
-        with fabric.api.settings(host_string=envy.ip(), user=envy.remote_user,
-                                 forward_agent=True, disable_known_hosts=True):
+                if args.scripts:
+                    scripts = [os.path.expanduser(script) for
+                               script in args.scripts]
+                elif 'provision_scripts' in envy.project_config:
+                    scripts = [os.path.expanduser(script) for script in
+                               envy.project_config['provision_scripts']]
+                elif 'provision_script_path' in envy.project_config:
+                    provision_script = envy.project_config['provision_script_path']
+                    scripts = [os.path.expanduser(provision_script)]
+                else:
+                    raise SystemExit('Please specify the path to your provision '
+                                     'script(s) by either using the `--scripts` '
+                                     'flag, or by defining the `provision_scripts`'
+                                     ' config option in your Envyfile')
 
-            if args.scripts:
-                scripts = [os.path.expanduser(script) for
-                           script in args.scripts]
-            elif 'provision_scripts' in envy.project_config:
-                scripts = [os.path.expanduser(script) for script in
-                           envy.project_config['provision_scripts']]
-            elif 'provision_script_path' in envy.project_config:
-                provision_script = envy.project_config['provision_script_path']
-                scripts = [os.path.expanduser(provision_script)]
-            else:
-                raise SystemExit('Please specify the path to your provision '
-                                 'script(s) by either using the `--scripts` '
-                                 'flag, or by defining the `provision_scripts`'
-                                 ' config option in your Envyfile')
+                for script in scripts:
+                    logging.info('Running provision script from: %s', script)
 
-            for script in scripts:
-                logging.info('Running provision script from: %s', script)
-
-                for i in range(24):
-                    try:
-                        path = script
-                        filename = os.path.basename(script)
-                        remote_path = '~/%s' % filename
-                        fabric.operations.run('if [ -e "$HOME/%s" ]; '
-                                              'then rm ~/%s; fi' %
-                                              (filename, filename))
-                        fabric.operations.put(path, remote_path, mode=0755)
-                        fabric.operations.run(remote_path)
-                        break
-                    except fabric.exceptions.NetworkError:
-                        logging.error('Unable to upload the provision script '
-                                      'from `%s`. Your ENVy is probably still '
-                                      'booting. Trying again in 10 seconds.')
-                        time.sleep(10)
-                logging.info('The provision script from `%s` has finished '
-                             'running.' % path)
+                    for i in range(24):
+                        try:
+                            path = script
+                            filename = os.path.basename(script)
+                            remote_path = '~/%s' % filename
+                            fabric.operations.run('if [ -e "$HOME/%s" ]; '
+                                                  'then rm ~/%s; fi' %
+                                                  (filename, filename))
+                            fabric.operations.put(path, remote_path, mode=0755)
+                            fabric.operations.run(remote_path)
+                            break
+                        except fabric.exceptions.NetworkError:
+                            logging.error('Unable to upload the provision script '
+                                          'from `%s`. Your ENVy is probably still '
+                                          'booting. Trying again in 10 seconds.')
+                            time.sleep(10)
+                    logging.info('The provision script from `%s` has finished '
+                                 'running.' % path)
+        else:
+            logging.error('Could not find IP.')


### PR DESCRIPTION
I think this happens if you have no ip allocated to the project

No hosts found. Please specify (single) host string for connection: ^CTraceback (most recent call last):
  File "/usr/local/bin/envy", line 8, in <module>
    load_entry_point('cloudenvy==0.0.2', 'console_scripts', 'envy')()
  File "/Users/anthonyyoung/code/cloudenvy/cloudenvy/main.py", line 389, in main
    args.func(args)
  File "/Users/anthonyyoung/code/cloudenvy/cloudenvy/main.py", line 135, in envy_up
    envy_provision(args)
  File "/Users/anthonyyoung/code/cloudenvy/cloudenvy/main.py", line 173, in envy_provision
    fabric.operations.run('if [ -e "$HOME/provision_script" ]; '
  File "/Library/Python/2.7/site-packages/Fabric-1.4.3-py2.7.egg/fabric/network.py", line 460, in host_prompting_wrapper
    host_string = raw_input("No hosts found. Please specify (single)"
