### PR TITLE
Install commands with python setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ config = dict(
     author='Brian Waldon',
     author_email='bcwaldon@gmail.com',
     install_requires=parse_requirements(),
-    packages=['cloudenvy'],
+    packages=['cloudenvy', 'cloudenvy.commands'],
     entry_points={
         'console_scripts': [
             'envy = cloudenvy.main:main',


### PR DESCRIPTION
Running python setup.py install doesn't install the commands directory so envy does not work except within the cloudenvy project dir.
