### PR TITLE
Convert KeyError to AttributeError

### DIFF
--- a/cloudenvy/config.py
+++ b/cloudenvy/config.py
@@ -58,7 +58,7 @@ class EnvyConfig(object):
         try:
             envy_name = args.name
             assert envy_name
-        except (AssertionError, KeyError):
+        except (AssertionError, AttributeError):
             pass
         else:
             config['project_config']['name'] = '%s-%s' % (base_name, envy_name)


### PR DESCRIPTION
A KeyError could not be raised from trying to access
args.name, but an AttributeError could.
