### PR TITLE
Add envy help command

### DIFF
--- a/cloudenvy/main.py
+++ b/cloudenvy/main.py
@@ -38,6 +38,17 @@ def _build_parser():
     EnvyDestroy(subparsers)
     EnvyRun(subparsers)
 
+    def find_command_help(config, args):
+        if args.command:
+            subparsers.choices[args.command].print_help()
+        else:
+            parser.print_help()
+
+    help_subparser = subparsers.add_parser('help',
+            help='Display help information for a specfiic command')
+    help_subparser.add_argument('command', action='store', nargs='?')
+    help_subparser.set_defaults(func=find_command_help)
+
     return parser
 
 


### PR DESCRIPTION
A user can run 'envy help' to see a listing of all available commands
or 'envy help X' to see help info for a specific command. This is
equivalent to using 'envy -h' and 'envy -h X'.
