### PR TITLE
When floating ips can not be allocated, you get a nasty ol' traceback 

### DIFF
--- a/cloudenvy/cloud.py
+++ b/cloudenvy/cloud.py
@@ -48,7 +48,8 @@ class CloudAPI(object):
         self.tenant_name = self.user_config['cloud'].get('os_tenant_name',
                                                          None)
         self.auth_url = self.user_config['cloud'].get('os_auth_url', None)
-        self.region_name = self.user_config['cloud'].get('os_region_name', None)
+        self.region_name = self.user_config['cloud'].get('os_region_name',
+                                                         None)
 
     @property
     def client(self):
@@ -148,7 +149,11 @@ class CloudAPI(object):
 
     @bad_request
     def allocate_floating_ip(self):
-        return self.client.floating_ips.create()
+        try:
+            fip = self.client.floating_ips.create()
+        except novaclient.exceptions.OverLimit, e:
+            raise SystemExit(logging.error(e))
+        return fip
 
     @bad_request
     @not_found


### PR DESCRIPTION
If your openstack install is having issues allocating floating ips (ie timing out or something) you get this traceback:

Traceback (most recent call last):
  File "/Users/jakedahn/Desktop/projects/cloudenvy/.venv/bin/envy", line 8, in <module>
    load_entry_point('cloudenvy==0.0.2', 'console_scripts', 'envy')()
  File "/Users/jakedahn/Desktop/projects/cloudenvy/cloudenvy/main.py", line 57, in main
    args.func(config, args)
  File "/Users/jakedahn/Desktop/projects/cloudenvy/cloudenvy/commands/envy_up.py", line 32, in run
    envy.build_server()
  File "/Users/jakedahn/Desktop/projects/cloudenvy/cloudenvy/envy.py", line 118, in build_server
    raise exceptions.FloatingIPAssignFailur()
AttributeError: 'module' object has no attribute 'FloatingIPAssignFailur'

Also worth noting that the exception name is totally a typo, missing an e.
