### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fabric>=1.5.0
+python-glanceclient
 python-novaclient
 pyyaml
-python-glanceclient
-requests==0.14.2


### PR DESCRIPTION
- python-glanceclient needs to be installed before python-novaclient
  due to prettytable deps and pip being silly
- remove the dependency on requests as it is not directly used
  by cloudenvy and there is no conflict we have to resolve manually
