### PR TITLE
Fix import of cloudenvy exceptions

### DIFF
--- a/cloudenvy/clouds/openstack.py
+++ b/cloudenvy/clouds/openstack.py
@@ -1,5 +1,4 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
-import exceptions
 import functools
 import getpass
 import logging
@@ -9,6 +8,7 @@ import uuid
 import novaclient.exceptions
 import novaclient.client
 
+from cloudenvy import exceptions
 
 def not_found(func):
     @functools.wraps(func)


### PR DESCRIPTION
Since `exceptions` is the name of a python built-in module, we were
getting path collisions where cloudenvy would import the built-in ones
instead of its own exceptions.
